### PR TITLE
Drop runtime reflection in Config

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -174,9 +174,7 @@ def baseLibraryDependencies (scalaVersion : String) : Seq[ModuleID] = {
         // DSL support:
         "org.bitbucket.inkytonik.dsinfo" %% "dsinfo" % dsinfoVersion,
         // Profiling:
-        "org.bitbucket.inkytonik.dsprofile" %% "dsprofile" % dsprofileVersion,
-        // Reflection
-        "org.scala-lang" % "scala-reflect" % scalaVersion
+        "org.bitbucket.inkytonik.dsprofile" %% "dsprofile" % dsprofileVersion
     )
 }
 

--- a/extras/src/main/scala/org/bitbucket/inkytonik/kiama/util/Config.scala
+++ b/extras/src/main/scala/org/bitbucket/inkytonik/kiama/util/Config.scala
@@ -22,7 +22,6 @@ class Config(args : Seq[String]) extends ScallopConf(args) {
 
     import org.bitbucket.inkytonik.kiama.util.{FileConsole, JLineConsole, StringConsole}
     import org.rogach.scallop.{ArgType, ValueConverter}
-    import scala.reflect.runtime.universe.TypeTag
 
     /**
      * The string emitter to use if a '--Koutput string' option is seen.
@@ -48,9 +47,6 @@ class Config(args : Seq[String]) extends ScallopConf(args) {
                     case _ =>
                         Right(None)
                 }
-
-            val tag = implicitly[TypeTag[Emitter]]
-
         }
 
     /**
@@ -85,9 +81,6 @@ class Config(args : Seq[String]) extends ScallopConf(args) {
                     case _ =>
                         Right(None)
                 }
-
-            val tag = implicitly[TypeTag[Console]]
-
         }
 
     /**


### PR DESCRIPTION
It appears runtime reflection is not necessary here. Dropping it removes a dependency
on the Scala compiler, speeds up start-up times significantly and allows Kiama projects
to be compiled ahead-of-time using sbt-native-image.