### PR TITLE
bump guava version from 30.1.1-jre to 32.1.1-jre

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -184,7 +184,7 @@ lazy val core =
         libraryDependencies ++=
             Seq(
                 // Caching:
-                "com.google.guava" % "guava" % "30.1.1-jre"
+                "com.google.guava" % "guava" % "32.1.1-jre"
             ),
 
         console/initialCommands := """


### PR DESCRIPTION
Sine guava `30.1.1-jre` is problematic [CVE-2023-2976](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2976) we bump it to `32.1.1-jre`