### PR TITLE
bump gson version from 2.8.2 to 2.8.9

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -218,7 +218,7 @@ lazy val extras =
                 "org.rogach" %% "scallop" % "4.0.3",
                 // Language server protocol:
                 "org.eclipse.lsp4j" % "org.eclipse.lsp4j" % "0.10.0",
-                "com.google.code.gson" % "gson" % "2.8.2",
+                "com.google.code.gson" % "gson" % "2.8.9",
                 // REPLs:
                 "jline" % "jline" % "2.14.6"
             ),


### PR DESCRIPTION
Sine `gson` in version `2.8.2` is problematic [CVE-2022-25647](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-25647) we bump it to the latest version with no vuln, keeping the same minor `2.8.9`