### PR TITLE
Better performance of bottomupNoBridges by avoiding triggering ClassCastException

### DIFF
--- a/core/src/main/scala/org/bitbucket/inkytonik/kiama/relation/Tree.scala
+++ b/core/src/main/scala/org/bitbucket/inkytonik/kiama/relation/Tree.scala
@@ -112,7 +112,7 @@ class Tree[T <: AnyRef with Product, +R <: T](val originalRoot : R, shape : Tree
      * A version of `bottomup` that doesn't traverse bridges.
      */
     def bottomupNoBridges(s : Strategy) : Strategy =
-        rule[Bridge[_]] { case b => b } <+
+        rule[Any] { case b : Bridge[_] => b } <+
             (all(bottomupNoBridges(s)) <* s)
 
     /**


### PR DESCRIPTION
Hello.

We have been profiling our application, which utilizes Kiama, and have observed large amounts of `ClassCastException` errors when it processes fairly large trees. These errors originate from strategies with the following (common) shape:
```scala
everywhere(rule[Exp] { case BinaryExp(...) => ... ; case UnaryExp(...) => ... })
```
We understand the presence of `ClassCastException` is part of the design as it is explicitly handled in several places as an indication that a strategy didn't apply. Nevertheless, the performance of the tree processing code significantly improved after rewriting these strategies against the `Any` type, since this doesn't trigger a `ClassCastException` when passing through nodes that aren't `Exp`.
```scala
// now use Any
everywhere(rule[Any] { case BinaryExp(...) => ... ; ...})
```
In our current profiling info, the next couple of places where the exception is thrown are `bottomupNoBridges` and `Cloner.deepclone`.

If patching `bottomupNoBridges` like in this PR, there's again a significant speedup. I can provide some numbers, but if there's any benchmark you'd prefer us to run, please let us know.

Flagging a strategy with the `Any` type isn't a pattern one sees in Kiama's examples, but it appears to be an effective way to improve performance. We're curious to get your comments/feedback on that.

Many thanks.