### PR TITLE
Documentation improvements

### DIFF
--- a/docs/Dataflow.md
+++ b/docs/Dataflow.md
@@ -14,7 +14,7 @@ calculation over the control flow graph to compute variable liveness.
 
 ## Abstract syntax
 
-File: [org.bitbucket.inkytonik.kiama.example.dataflow.DataflowTree.scala](https://github.com/inkytonik/kiama/blob/master/library/src/test/scala/org/bitbucket/inkytonik/kiama/example/dataflow/DataflowTree.scala)
+File: [org.bitbucket.inkytonik.kiama.example.dataflow.DataflowTree.scala](/extras/src/test/scala/org/bitbucket/inkytonik/kiama/example/dataflow/DataflowTree.scala)
 
 Programs for this example consist of a single statement.
 
@@ -44,7 +44,7 @@ type Var = String
 
 ## Control flow graph
 
-File: [org.bitbucket.inkytonik.kiama.example.dataflow.Dataflow.scala](https://github.com/inkytonik/kiama/blob/master/library/src/test/scala/org/bitbucket/inkytonik/kiama/example/dataflow/Dataflow.scala)
+File: [org.bitbucket.inkytonik.kiama.example.dataflow.Dataflow.scala](/extras/src/test/scala/org/bitbucket/inkytonik/kiama/example/dataflow/Dataflow.scala)
 
 The control flow graph is defined by the `succ` attribute. `s->succ`
 is the set of statements to which control can flow from statement `s`.
@@ -101,7 +101,7 @@ indicated by `=>`, not partial functions.)
 
 ## Variable definitions and uses
 
-File: [org.bitbucket.inkytonik.kiama.example.dataflow.Dataflow.scala](https://github.com/inkytonik/kiama/blob/master/library/src/test/scala/org/bitbucket/inkytonik/kiama/example/dataflow/Dataflow.scala)
+File: [org.bitbucket.inkytonik.kiama.example.dataflow.Dataflow.scala](/extras/src/test/scala/org/bitbucket/inkytonik/kiama/example/dataflow/Dataflow.scala)
 
 The next step is to specify the variables that are defined and used
 directly by each kind of statement. We specify two attributes
@@ -136,7 +136,7 @@ val uses : Stm ==> Set[Var] =
 
 ## Variable liveness
 
-File: [org.bitbucket.inkytonik.kiama.example.dataflow.Dataflow.scala](https://github.com/inkytonik/kiama/blob/master/library/src/test/scala/org/bitbucket/inkytonik/kiama/example/dataflow/Dataflow.scala)
+File: [org.bitbucket.inkytonik.kiama.example.dataflow.Dataflow.scala](/extras/src/test/scala/org/bitbucket/inkytonik/kiama/example/dataflow/Dataflow.scala)
 
 The standard approach to calculating variable liveness is to compute
 `in` and `out` sets for each statement. `in (s)` contains all
@@ -181,7 +181,7 @@ equations.
 
 ## Tests
 
-File: [org.bitbucket.inkytonik.kiama.example.dataflow.DataflowTests.scala](https://github.com/inkytonik/kiama/blob/master/library/src/test/scala/org/bitbucket/inkytonik/kiama/example/dataflow/DataflowTests.scala)
+File: [org.bitbucket.inkytonik.kiama.example.dataflow.DataflowTests.scala](/extras/src/test/scala/org/bitbucket/inkytonik/kiama/example/dataflow/DataflowTests.scala)
 
 A test of live variable computations for a small program involving a
 while loop.

--- a/docs/Imperative.md
+++ b/docs/Imperative.md
@@ -17,7 +17,7 @@ library, so there is also quite a bit of test-related scaffolding.
 
 ## Abstract syntax
 
-File: [org.bitbucket.inkytonik.kiama.example.imperative.Imperative.scala](https://github.com/inkytonik/kiama/blob/master/library/src/test/scala/org/bitbucket/inkytonik/kiama/example/imperative/Imperative.scala)
+File: [org.bitbucket.inkytonik.kiama.example.imperative.Imperative.scala](/extras/src/test/scala/org/bitbucket/inkytonik/kiama/example/imperative/Imperative.scala)
 
 Programs for this example consist of a single statement of which
 some standard varieties are available.
@@ -55,7 +55,7 @@ type Idn = String
 
 ## Parsing
 
-File: [org.bitbucket.inkytonik.kiama.example.imperative.Imperative.scala](https://github.com/inkytonik/kiama/blob/master/library/src/test/scala/org/bitbucket/inkytonik/kiama/example/imperative/Imperative.scala)
+File: [org.bitbucket.inkytonik.kiama.example.imperative.Imperative.scala](/extras/src/test/scala/org/bitbucket/inkytonik/kiama/example/imperative/Imperative.scala)
 
 The parser is written using Kiama's [parsing combinator library](Parsing).
 Lazy values are used to enable the parsers to be defined in any order.
@@ -132,7 +132,7 @@ lazy val keyword : Parser[String] =
 
 ## Pretty-printing
 
-File: [org.bitbucket.inkytonik.kiama.example.imperative.PrettyPrinter.scala](https://github.com/inkytonik/kiama/blob/master/library/src/test/scala/org/bitbucket/inkytonik/kiama/example/imperative/PrettyPrinter.scala)
+File: [org.bitbucket.inkytonik.kiama.example.imperative.PrettyPrinter.scala](/extras/src/test/scala/org/bitbucket/inkytonik/kiama/example/imperative/PrettyPrinter.scala)
 
 The example includes a simple pretty-printer that uses Kiama's
 [pretty-printing library](PrettyPrinting).  See the end of the
@@ -141,7 +141,7 @@ description of the imperative pretty printer.
 
 ## Read-eval-print loop
 
-File: [org.bitbucket.inkytonik.kiama.example.imperative.Imperative.scala](https://github.com/inkytonik/kiama/blob/master/library/src/test/scala/org/bitbucket/inkytonik/kiama/example/imperative/Imperative.scala)
+File: [org.bitbucket.inkytonik.kiama.example.imperative.Imperative.scala](/extras/src/test/scala/org/bitbucket/inkytonik/kiama/example/imperative/Imperative.scala)
 
 Kiama provides some basic facilities to make it easy to define
 [read-eval-print loops (REPLs)](ReadEvalPrintLoops). In the imperative
@@ -163,7 +163,7 @@ object Imperative extends ParsingREPL[Stmt] with Parser {
 
 ## Test scaffolding
 
-File: [org.bitbucket.inkytonik.kiama.example.imperative.Imperative.scala](https://github.com/inkytonik/kiama/blob/master/library/src/test/scala/org/bitbucket/inkytonik/kiama/example/imperative/Imperative.scala)
+File: [org.bitbucket.inkytonik.kiama.example.imperative.Imperative.scala](/extras/src/test/scala/org/bitbucket/inkytonik/kiama/example/imperative/Imperative.scala)
 
 The main test scaffolding provided in this example is
 [ScalaCheck](http://code.google.com/p/scalacheck/) support for
@@ -225,7 +225,7 @@ compute similar metrics on expressions.
 
 ## Running
 
-File: [org.bitbucket.inkytonik.kiama.example.imperative.Imperative.scala](https://github.com/inkytonik/kiama/blob/master/library/src/test/scala/org/bitbucket/inkytonik/kiama/example/imperative/Imperative.scala)
+File: [org.bitbucket.inkytonik.kiama.example.imperative.Imperative.scala](/extras/src/test/scala/org/bitbucket/inkytonik/kiama/example/imperative/Imperative.scala)
 
 To run the read-eval-print loop to parse programs and print their tree representations:
 
@@ -252,7 +252,7 @@ Hit ENTER to generate an instance:
 
 ## Tests
 
-File: [org.bitbucket.inkytonik.kiama.rewriting.RewriterTests.scala](http://code.google.com/p/kiama/source/browse/library/src/test/scala/org/bitbucket/inkytonik/kiama/rewriting/RewriterTests.scala)
+File: [org.bitbucket.inkytonik.kiama.rewriting.RewriterTests.scala](/extras/src/test/scala/org/bitbucket/inkytonik/kiama/rewriting/RewriterTests.scala)
 
 A collection of tests that rewrite imperative language expressions and statements.
 
@@ -260,7 +260,7 @@ A collection of tests that rewrite imperative language expressions and statement
 sbt 'test-only org.bitbucket.inkytonik.kiama.rewriting.RewriterTests'
 ```
 
-File: [org.bitbucket.inkytonik.kiama.rewriting.UniplateTests.scala](http://code.google.com/p/kiama/source/browse/library/src/test/scala/org/bitbucket/inkytonik/kiama/rewriting/UniplateTests.scala)
+File: [org.bitbucket.inkytonik.kiama.rewriting.UniplateTests.scala](/extras/src/test/scala/org/bitbucket/inkytonik/kiama/rewriting/UniplateTests.scala)
 
 A collection of rewriting tests based on examples in a Haskell
 Workshop 2007 paper about the

--- a/docs/Lambda.md
+++ b/docs/Lambda.md
@@ -13,7 +13,7 @@ a simple un-typed version of the
 
 ## Abstract syntax
 
-File: [org.bitbucket.inkytonik.kiama.example.lambda.Lambda.scala](https://github.com/inkytonik/kiama/blob/master/library/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda/Lambda.scala)
+File: [org.bitbucket.inkytonik.kiama.example.lambda.Lambda.scala](/extras/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda/Lambda.scala)
 
 Programs for this example consist of expressions.
 
@@ -57,7 +57,7 @@ case class Sub (m : Exp, x : Idn, n : Exp) extends Exp
 
 ## Parser
 
-File: [org.bitbucket.inkytonik.kiama.example.lambda.Lambda.scala](https://github.com/inkytonik/kiama/blob/master/library/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda/Lambda.scala)
+File: [org.bitbucket.inkytonik.kiama.example.lambda.Lambda.scala](/extras/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda/Lambda.scala)
 
 The [parser](Parsing) is a simple application of Scala's [parser combinators](ParserCombs).
 (See the [Imperative](Imperative) example for more explanation of a similar parser.)
@@ -87,7 +87,7 @@ lazy val idn =
 
 ## Evaluation
 
-File: [org.bitbucket.inkytonik.kiama.example.lambda.Lambda.scala](https://github.com/inkytonik/kiama/blob/master/library/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda/Lambda.scala)
+File: [org.bitbucket.inkytonik.kiama.example.lambda.Lambda.scala](/extras/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda/Lambda.scala)
 
 We use an evaluation scheme from lecture notes by Kristoffer H. Rose,
 [Explicit Substitution - Tutorial and Survey](http://www.brics.dk/LS/96/3/BRICS-LS-96-3/BRICS-LS-96-3.html).
@@ -172,7 +172,7 @@ case Sub (m, x, n) if ! (fv (m) contains (x)) => m
 
 ## Free variables
 
-File: [org.bitbucket.inkytonik.kiama.example.lambda.Lambda.scala](https://github.com/inkytonik/kiama/blob/master/library/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda/Lambda.scala)
+File: [org.bitbucket.inkytonik.kiama.example.lambda.Lambda.scala](/extras/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda/Lambda.scala)
 
 The auxiliary function `fv` provides the set of variables that are
 free (i.e., not bound) in a given expression.
@@ -191,7 +191,7 @@ def fv (t : Exp) : Set[Idn] = {
 
 ## Running
 
-File: [org.bitbucket.inkytonik.kiama.example.lambda.Lambda.scala](https://github.com/inkytonik/kiama/blob/master/library/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda/Lambda.scala)
+File: [org.bitbucket.inkytonik.kiama.example.lambda.Lambda.scala](/extras/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda/Lambda.scala)
 
 To run the read-eval-print loop to parse programs, evaluate them to a normal form
 and print the result:
@@ -218,7 +218,7 @@ Hit ENTER to generate an instance:
 
 ## Tests
 
-File: [org.bitbucket.inkytonik.kiama.example.lambda.LambdaTests.scala](https://github.com/inkytonik/kiama/blob/master/library/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda/LambdaTests.scala)
+File: [org.bitbucket.inkytonik.kiama.example.lambda.LambdaTests.scala](/extras/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda/LambdaTests.scala)
 
 Some simple tests of lambda calculus evaluation.
 

--- a/docs/Lambda2.md
+++ b/docs/Lambda2.md
@@ -17,7 +17,7 @@ with a user-selected mechanism.
 
 ## Abstract syntax
 
-File: [org.bitbucket.inkytonik.kiama.example.lambda2.LambdaTree.scala](https://github.com/inkytonik/kiama/blob/master/library/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda2/LambdaTree.scala)
+File: [org.bitbucket.inkytonik.kiama.example.lambda2.LambdaTree.scala](/extras/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda2/LambdaTree.scala)
 
 Programs for this example consist of expressions represented by the
 `Exp` type. `Exp` extends [Attributable](Attribution#markdown-header-attributable)
@@ -75,7 +75,7 @@ case class Bind (name : Idn, tipe : Type, exp : Exp)
 
 ## Types
 
-File: [org.bitbucket.inkytonik.kiama.example.lambda2.LambdaTree.scala](https://github.com/inkytonik/kiama/blob/master/library/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda2/LambdaTree.scala)
+File: [org.bitbucket.inkytonik.kiama.example.lambda2.LambdaTree.scala](/extras/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda2/LambdaTree.scala)
 
 It is possible to support a large variety of primitive types, but
 adding new ones does not really add anything meaningful to the
@@ -95,7 +95,7 @@ case class FunType (arg : Type, res : Type) extends Type
 
 ## Operations
 
-File: [org.bitbucket.inkytonik.kiama.example.lambda2.LambdaTree.scala](https://github.com/inkytonik/kiama/blob/master/library/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda2/LambdaTree.scala)
+File: [org.bitbucket.inkytonik.kiama.example.lambda2.LambdaTree.scala](/extras/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda2/LambdaTree.scala)
 
 Primitive binary operations are represented by `Op` instances. Each
 `Op` subclass provides an evaluation method to actually run the
@@ -123,7 +123,7 @@ case object SubOp extends Op {
 
 ## Pretty printing
 
-File: [org.bitbucket.inkytonik.kiama.example.lambda2.PrettyPrinter.scala](https://github.com/inkytonik/kiama/blob/master/library/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda2/PrettyPrinter.scala)
+File: [org.bitbucket.inkytonik.kiama.example.lambda2.PrettyPrinter.scala](/extras/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda2/PrettyPrinter.scala)
 
 The result of an expression evaluation is pretty printed using a
 straight-forward functional application of Kiama's
@@ -202,7 +202,7 @@ object PrettyPrinter extends org.bitbucket.inkytonik.kiama.output.PrettyPrinter 
 
 ## Parser
 
-File: [org.bitbucket.inkytonik.kiama.example.lambda2.SyntaxAnalyser.scala](https://github.com/inkytonik/kiama/blob/master/library/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda2/SyntaxAnalyser.scala)
+File: [org.bitbucket.inkytonik.kiama.example.lambda2.SyntaxAnalyser.scala](/extras/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda2/SyntaxAnalyser.scala)
 
 The [parser](Parsing) is a simple application of Scala's [parser combinators](ParserCombs).
 (See the [Imperative](Imperative) example for more explanation of a similar parser.)  Types are optional
@@ -252,7 +252,7 @@ lazy val number =
 
 ## Name and type analysis
 
-File: [org.bitbucket.inkytonik.kiama.example.lambda.Analyser.scala](https://github.com/inkytonik/kiama/blob/master/library/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda/Analyser.scala)
+File: [org.bitbucket.inkytonik.kiama.example.lambda2.Analyser.scala](/extras/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda2/Analyser.scala)
 
 After an abstract syntax tree has been built, we check it for semantic
 correctness. In this example that means we make sure that each
@@ -267,7 +267,7 @@ semantic analysis, which are described in the next two sections.
 
 ## An Environment-based Analysis
 
-File: [org.bitbucket.inkytonik.kiama.example.lambda.Analyser.scala](https://github.com/inkytonik/kiama/blob/master/library/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda/Analyser.scala)
+File: [org.bitbucket.inkytonik.kiama.example.lambda2.Analyser.scala](/extras/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda2/Analyser.scala)
 
 A classical solution to this kind of analysis problem is to construct
 an _environment_ (usually called a _symbol table_ in a compiler
@@ -388,7 +388,7 @@ case e @ Var (x) => (e->env).find { case (y,_) => x == y } match {
 
 ## A Reference-based Analysis
 
-File: [org.bitbucket.inkytonik.kiama.example.lambda.Analyser.scala](https://github.com/inkytonik/kiama/blob/master/library/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda/Analyser.scala)
+File: [org.bitbucket.inkytonik.kiama.example.lambda2.Analyser.scala](/extras/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda2/Analyser.scala)
 
 Instead of building a separate environment structure to keep track of
 variables that are in scope, we can use the tree itself. In this
@@ -434,7 +434,7 @@ def lookup (name : Idn) : Exp => Option[Lam] =
 
 ## Evaluation mechanisms
 
-File: [org.bitbucket.inkytonik.kiama.example.lambda2.Evaluators.scala](https://github.com/inkytonik/kiama/blob/master/library/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda2/Evaluators.scala)
+File: [org.bitbucket.inkytonik.kiama.example.lambda2.Evaluators.scala](/extras/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda2/Evaluators.scala)
 
 The example includes a number of different evaluation mechanisms
 defined by [rewrite rules](Rewriting). The evaluation strategies used
@@ -446,7 +446,7 @@ on how they work.
 
 ## Repeated reduction with meta-level substitution
 
-File: [org.bitbucket.inkytonik.kiama.example.lambda2.Reduce.scala](https://github.com/inkytonik/kiama/blob/master/library/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda2/Reduce.scala)
+File: [org.bitbucket.inkytonik.kiama.example.lambda2.Reduce.scala](/extras/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda2/Reduce.scala)
 
 The standard evaluation rule for lambda calculus is _beta reduction_ which we can
 write as follows, given a function that performs variable substitution.
@@ -507,7 +507,7 @@ def eval (exp : Exp) : Exp =
 
 ## Repeated reduction with explicit substitution
 
-File: [org.bitbucket.inkytonik.kiama.example.lambda2.ReduceSubst.scala](https://github.com/inkytonik/kiama/blob/master/library/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda2/ReduceSubst.scala)
+File: [org.bitbucket.inkytonik.kiama.example.lambda2.ReduceSubst.scala](/extras/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda2/ReduceSubst.scala)
 
 Instead of encoding substitution separately, we can incorporate it
 into the language and the rewrite rules by using `Let` constructs to
@@ -574,7 +574,7 @@ override lazy val s =
 
 ## Innermost evaluation
 
-File: [org.bitbucket.inkytonik.kiama.example.lambda2.InnermostSubst.scala](https://github.com/inkytonik/kiama/blob/master/library/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda2/InnermostSubst.scala)
+File: [org.bitbucket.inkytonik.kiama.example.lambda2.InnermostSubst.scala](/extras/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda2/InnermostSubst.scala)
 
 An alternative to `reduce` is to explicitly use an `innermost`
 strategy so that the order of evaluation is more precisely defined. In
@@ -600,7 +600,7 @@ def innermost (s : => Strategy) : Strategy =
 
 ## Eager evaluation
 
-File: [org.bitbucket.inkytonik.kiama.example.lambda2.EagerSubst.scala](https://github.com/inkytonik/kiama/blob/master/library/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda2/EagerSubst.scala)
+File: [org.bitbucket.inkytonik.kiama.example.lambda2.EagerSubst.scala](/extras/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda2/EagerSubst.scala)
 
 Some functional languages such as the ML family use an _eager
 evaluation_ method where the arguments to functions are evaluated
@@ -628,7 +628,7 @@ be applied to the application.
 
 ## Lazy evaluation
 
-File: [org.bitbucket.inkytonik.kiama.example.lambda2.LazySubst.scala](https://github.com/inkytonik/kiama/blob/master/library/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda2/LazySubst.scala)
+File: [org.bitbucket.inkytonik.kiama.example.lambda2.LazySubst.scala](/extras/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda2/LazySubst.scala)
 
 Instead of evaluating function arguments before substitution, we can
 use _lazy evaluation_ where arguments are only evaluated if and when
@@ -644,8 +644,8 @@ override lazy val s : Strategy =
 
 ## Parallel substitution
 
-Files: [org.bitbucket.inkytonik.kiama.example.lambda2.ParEagerSubst.scala](https://github.com/inkytonik/kiama/blob/master/library/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda2/ParEagerSubst.scala)
-[org.bitbucket.inkytonik.kiama.example.lambda2.ParLazySubst.scala](https://github.com/inkytonik/kiama/blob/master/library/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda2/ParLazySubst.scala)
+Files: [org.bitbucket.inkytonik.kiama.example.lambda2.ParEagerSubst.scala](/extras/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda2/ParEagerSubst.scala)
+[org.bitbucket.inkytonik.kiama.example.lambda2.ParLazySubst.scala](/extras/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda2/ParLazySubst.scala)
 
 Variants of eager and lazy evaluation can be written that manage
 substitutions in parallel rather than in sequence as in the earlier
@@ -656,7 +656,7 @@ that share and update results as evaluation proceeds.
 
 ## Running
 
-File: [org.bitbucket.inkytonik.kiama.example.lambda2.Lambda.scala](https://github.com/inkytonik/kiama/blob/master/library/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda2/Lambda.scala)
+File: [org.bitbucket.inkytonik.kiama.example.lambda2.Lambda.scala](/extras/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda2/Lambda.scala)
 
 The example code includes a [read-eval-print loop](ReadEvalPrintLoops)
 that reads an expression from the user, parses the expression,
@@ -698,7 +698,7 @@ lambda2>
 
 ## Tests
 
-File: [org.bitbucket.inkytonik.kiama.example.lambda2.LambdaTests.scala](https://github.com/inkytonik/kiama/blob/master/library/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda2/LambdaTests.scala)
+File: [org.bitbucket.inkytonik.kiama.example.lambda2.LambdaTests.scala](/extras/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda2/LambdaTests.scala)
 
 Some simple tests of lambda calculus evaluation using all of the strategies.
 

--- a/docs/Messaging.md
+++ b/docs/Messaging.md
@@ -17,7 +17,7 @@ The following examples make particular use of the messaging module:
 
 ## Messaging
 
-File: [org.bitbucket.inkytonik.kiama.util.Messaging.scala](http://code.google.com/p/kiama/source/browse/library/src/main/scala/org/bitbucket/inkytonik/kiama/util/Messaging.scala)
+File: [org.bitbucket.inkytonik.kiama.util.Messaging.scala](/extras/src/main/scala/org/bitbucket/inkytonik/kiama/util/Messaging.scala)
 
 The `Messaging` object implements the messaging module. To store the
 messages it contains a list buffer, each item of which contains position

--- a/docs/PrettyPrinting.md
+++ b/docs/PrettyPrinting.md
@@ -513,7 +513,7 @@ depending on line width.
 ## Functional pretty printing: the Imperative language
 
 As a more complex example, consider
-[pretty printing](https://github.com/inkytonik/kiama/blob/master/library/src/test/scala/org/bitbucket/inkytonik/kiama/example/imperative/PrettyPrinter.scala)
+[pretty printing](/extras/src/test/scala/org/bitbucket/inkytonik/kiama/example/imperative/PrettyPrinter.scala)
 for the [Imperative](Imperative) language. We implement a function `show` that
 converts any imperative language abstract syntax tree node into a
 document. `show` uses `showbin` that abstracts documents for

--- a/docs/ReadEvalPrintLoops.md
+++ b/docs/ReadEvalPrintLoops.md
@@ -23,7 +23,7 @@ the REPL support:
 
 ## The `REPL` trait
 
-File: [org.bitbucket.inkytonik.kiama.util.REPL.scala](http://code.google.com/p/kiama/source/browse/library/src/main/scala/org/bitbucket/inkytonik/kiama/util/REPL.scala)
+File: [org.bitbucket.inkytonik.kiama.util.REPL.scala](/extras/src/main/scala/org/bitbucket/inkytonik/kiama/util/REPL.scala)
 
 The common interface for REPLs built using Kiama is provided by the
 `REPL` trait. It provides a `main` function that:
@@ -55,7 +55,7 @@ editing and history.
 
 ## `ParsingREPL`
 
-File: [org.bitbucket.inkytonik.kiama.util.REPL.scala](http://code.google.com/p/kiama/source/browse/library/src/main/scala/org/bitbucket/inkytonik/kiama/util/REPL.scala)
+File: [org.bitbucket.inkytonik.kiama.util.REPL.scala](/extras/src/main/scala/org/bitbucket/inkytonik/kiama/util/REPL.scala)
 
 `REPL` provides a very general interface. Kiama also provides a number
 of more specialised instantiations of `REPL` for common situations.
@@ -77,7 +77,7 @@ providing a `processline` implementation you should provide:
 
 ## `GeneratingREPL`
 
-File: [org.bitbucket.inkytonik.kiama.util.REPLTests.scala](http://code.google.com/p/kiama/source/browse/library/src/test/scala/org/bitbucket/inkytonik/kiama/util/REPLTests.scala)
+File: [org.bitbucket.inkytonik.kiama.util.REPLTests.scala](/extras/src/test/scala/org/bitbucket/inkytonik/kiama/util/REPLTests.scala)
 
 A less useful variant of `REPL` is `GeneratingREPL[T]` which provides
 a standard interface for REPLs that randomly generate program

--- a/docs/Rewritable.md
+++ b/docs/Rewritable.md
@@ -46,7 +46,7 @@ for some reason (e.g., wrong number or type), the `illegalArgs` method
 should be called.  By default, `illegalArgs` throws an `illegalArgumentException`.
 
 See Kiama's `imperative` example (file
-[ASTNonCase.scala](https://github.com/inkytonik/kiama/blob/master/library/src/test/scala/org/bitbucket/inkytonik/kiama/example/imperative/ASTNonCase.scala))
+[ImperativeNonCaseTree.scala](/extras/src/test/scala/org/bitbucket/inkytonik/kiama/example/imperative/ImperativeNonCaseTree.scala))
 for an example of how to define `Rewritable` instances.
 
 Up: [Context](Context), Prev: [Case Classes](CaseClasses)

--- a/docs/Rewriting.md
+++ b/docs/Rewriting.md
@@ -213,7 +213,7 @@ returns a strategy, not a term.  The returned strategy is applied to the
 subject term.  Therefore, `rulefs` is most useful in situations where you
 want to match some pattern to bind some variables, then use those
 variables in another strategy.  See the
-File: [ParLazy.scala](https://github.com/inkytonik/kiama/blob/master/library/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda2/ParLazy.scala)
+File: [ParLazy.scala](/extras/src/test/scala/org/bitbucket/inkytonik/kiama/example/lambda2/ParLazy.scala)
 of the lambda2 example for uses of `rulefs`.
 
 Stratego allows the use of concrete syntax in strategies. For example


### PR DESCRIPTION

Fixed various paths that were incorrect. 

- docs/Rewritable.md: also changed the dst file, since the referenced file didn't exist the only file that does rewrite was the ImperativeNonCaseTree.scala
- docs/Messaging.md: while the path is corrected to point where the file should be expected I couldn't find the actual file :( A quick google didn't return any results...
- docs/Lambda2.md: Converted the links to point to lambda2 files